### PR TITLE
Make deployment strategy work for both types

### DIFF
--- a/osu/s3-nginx-proxy/templates/deployment.yaml
+++ b/osu/s3-nginx-proxy/templates/deployment.yaml
@@ -12,8 +12,13 @@ spec:
   selector:
     matchLabels:
       {{- include "s3-nginx-proxy-chart.selectorLabels" . | nindent 6 }}
+  {{- if eq $kind "Deployment"}}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- else }}
   updateStrategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The deployment.spec requires `strategy` instead of `updateStrategy`