### PR TITLE
✨ Add support for kubernetes-secrets-exporter HTTPS listening mode

### DIFF
--- a/osu/kubernetes-secrets-exporter/templates/deployment.yaml
+++ b/osu/kubernetes-secrets-exporter/templates/deployment.yaml
@@ -27,6 +27,15 @@ spec:
       serviceAccountName: {{ include "kubernetes-secrets-exporter.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if eq .Values.server.listenMode "https" }}
+      volumes:
+        - name: ca-certs
+          secret:
+            secretName: {{ include "kubernetes-secrets-exporter.fullname" $ }}-ca
+        - name: tls-certs
+          secret:
+            secretName: {{ .Values.server.https.certificate.existingSecret }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -37,6 +46,7 @@ spec:
             - name: http
               containerPort: 5000
               protocol: TCP
+          {{- if eq .Values.server.listenMode "http" }}
           livenessProbe:
             httpGet:
               path: /
@@ -45,16 +55,41 @@ spec:
             httpGet:
               path: /
               port: http
+          {{- else }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: LISTEN_MODE
+              value: {{ .Values.server.listenMode }}
+            {{- with .Values.server.trustProxy }}
+            - name: TRUST_PROXY
+              value: {{ . | toString }}
+            {{- end }}
             - name: CONFIGMAP_NAME
               value: {{ include "kubernetes-secrets-exporter.fullname" . }}
+            {{- if eq .Values.server.listenMode "http" }}
             - name: SSL_CLIENT_SUBJECT_HEADER
-              value: ssl-client-subject-dn
+              value: {{ .Values.server.http.commonNameHeader }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if eq .Values.server.listenMode "https" }}
+          volumeMounts:
+            - name: ca-certs
+              mountPath: /ca-certs
+              readOnly: true
+            - name: tls-certs
+              mountPath: /tls-certs
+              readOnly: true
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/osu/kubernetes-secrets-exporter/templates/deployment.yaml
+++ b/osu/kubernetes-secrets-exporter/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             secretName: {{ include "kubernetes-secrets-exporter.fullname" $ }}-ca
         - name: tls-certs
           secret:
-            secretName: {{ .Values.server.https.certificate.existingSecret }}
+            secretName: {{ .Values.server.https.certificate.existingSecret | default (printf "%s-tls" (include "kubernetes-secrets-exporter.fullname" $)) }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/osu/kubernetes-secrets-exporter/templates/ingress.yaml
+++ b/osu/kubernetes-secrets-exporter/templates/ingress.yaml
@@ -19,9 +19,13 @@ metadata:
   labels:
     {{- include "kubernetes-secrets-exporter.labels" . | nindent 4 }}
   annotations:
+    {{- if eq .Values.server.listenMode "http" }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
     nginx.ingress.kubernetes.io/auth-tls-secret: "{{ .Release.Namespace }}/{{ include "kubernetes-secrets-exporter.fullname" $ }}-ca"
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
+    {{- else }}
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    {{- end }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -29,7 +33,7 @@ spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if and .Values.ingress.tls (eq .Values.server.listenMode "http") }}
   tls:
     {{- range .Values.ingress.tls }}
     - hosts:

--- a/osu/kubernetes-secrets-exporter/templates/service.yaml
+++ b/osu/kubernetes-secrets-exporter/templates/service.yaml
@@ -1,3 +1,6 @@
+{{- if and (eq .Values.server.listenMode "http") (not (eq .Values.service.type "ClusterIP")) }}
+  {{- fail "Service type must be ClusterIP when listenMode is http, as in this configuration, the app should be put behind a reverse proxy internally to handle client authentication." }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/osu/kubernetes-secrets-exporter/templates/service.yaml
+++ b/osu/kubernetes-secrets-exporter/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "kubernetes-secrets-exporter.fullname" . }}
   labels:
     {{- include "kubernetes-secrets-exporter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/osu/kubernetes-secrets-exporter/templates/tls-certificate.yaml
+++ b/osu/kubernetes-secrets-exporter/templates/tls-certificate.yaml
@@ -1,0 +1,16 @@
+{{- if and (eq .Values.server.listenMode "https") (eq .Values.server.https.certificate.existingSecret nil) }}
+{{- with .Values.server.https.certificate }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kubernetes-secrets-exporter.fullname" $ }}-tls
+spec:
+  secretName: {{ include "kubernetes-secrets-exporter.fullname" $ }}-tls
+  dnsNames:
+    {{- toYaml (required ".Values.server.https.certificate.dnsNames is required" .dnsNames) | nindent 4 }}
+  issuerRef:
+    {{- toYaml (required ".Values.server.https.certificate.issuerRef is required" .issuerRef) | nindent 4 }}
+  usages:
+    {{- toYaml (required ".Values.server.https.certificate.usages is required" .usages) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/osu/kubernetes-secrets-exporter/values.schema.json
+++ b/osu/kubernetes-secrets-exporter/values.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "required": [
+    "server"
+  ],
+  "properties": {
+    "server": {
+      "type": "object",
+      "properties": {
+        "listenMode": {
+          "type": "string",
+          "enum": [
+            "http",
+            "https"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/osu/kubernetes-secrets-exporter/values.yaml
+++ b/osu/kubernetes-secrets-exporter/values.yaml
@@ -10,6 +10,15 @@ secrets:
 certificates:
   ca.crt: ""
 
+server:
+  # listenMode: http or https
+  trustProxy: false
+  http:
+    commonNameHeader: ssl-client-subject-dn
+  https:
+    certificate: {}
+      # existingSecret: ""
+
 extraEnv: {}
 
 replicaCount: 1

--- a/osu/kubernetes-secrets-exporter/values.yaml
+++ b/osu/kubernetes-secrets-exporter/values.yaml
@@ -64,6 +64,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 5000
+  # annotations: {}
 
 ingress:
   enabled: true

--- a/osu/kubernetes-secrets-exporter/values.yaml
+++ b/osu/kubernetes-secrets-exporter/values.yaml
@@ -16,8 +16,14 @@ server:
   http:
     commonNameHeader: ssl-client-subject-dn
   https:
-    certificate: {}
+    certificate:
       # existingSecret: ""
+      dnsNames:
+        - chart-example.local
+      usages:
+        - digital signature
+        - key encipherment
+      # issuerRef: {}
 
 extraEnv: {}
 


### PR DESCRIPTION
This PR adds support for https://github.com/ppy/kubernetes-secrets-exporter/pull/1.

To compliment the app's native HTTPS support, it enables automatic TLS certificate provisioning through cert-manager (as cert-manager's ingress shim integration no longer applies).

**Please leave merge to me as this PR depends on https://github.com/ppy/kubernetes-secrets-exporter/pull/1 being merged, a tag being pushed there, and version numbers being bumped here as well.**